### PR TITLE
return the initialized dictionary instead of storing it in a global variable

### DIFF
--- a/backward_compatibility.go
+++ b/backward_compatibility.go
@@ -1,0 +1,34 @@
+package browscap_go
+
+import "fmt"
+
+var backwardCompatibleBrowsCap *BrowsCap
+
+// Deprecated: Use NewBrowsCapFromFile
+func InitBrowsCap(path string, force bool) error {
+	if backwardCompatibleBrowsCap != nil && !force {
+		return nil
+	}
+	var err error
+
+	// Load ini file
+	if backwardCompatibleBrowsCap, err = NewBrowsCapFromFile(path); err != nil {
+		return fmt.Errorf("browscap: An error occurred while reading file, %v ", err)
+	}
+
+	return nil
+}
+
+// Deprecated: Use BrowsCap.InitializedVersion
+func InitializedVersion() string {
+	return backwardCompatibleBrowsCap.InitializedVersion()
+}
+
+// Deprecated: Use BrowsCap.GetBrowser
+func GetBrowser(userAgent string) (browser *Browser, ok bool) {
+	if backwardCompatibleBrowsCap == nil {
+		return
+	}
+
+	return backwardCompatibleBrowsCap.GetBrowser(userAgent)
+}

--- a/browscap.go
+++ b/browscap.go
@@ -16,29 +16,13 @@ const (
 	CheckVersionUrl = "http://browscap.org/version-number"
 )
 
-var (
-	dict        *dictionary
-	initialized bool
-	version     string
-)
-
-func InitBrowsCap(path string, force bool) error {
-	if initialized && !force {
-		return nil
-	}
-	var err error
-
-	// Load ini file
-	if dict, err = loadFromIniFile(path); err != nil {
-		return fmt.Errorf("browscap: An error occurred while reading file, %v ", err)
-	}
-
-	initialized = true
-	return nil
+type BrowsCap struct {
+	dict    *dictionary
+	version string
 }
 
-func InitializedVersion() string {
-	return version
+func (browscap *BrowsCap) InitializedVersion() string {
+	return browscap.version
 }
 
 func LastVersion() (string, error) {
@@ -87,20 +71,16 @@ func DownloadFile(saveAs string) error {
 	return nil
 }
 
-func GetBrowser(userAgent string) (browser *Browser, ok bool) {
-	if !initialized {
-		return
-	}
-
+func (browscap *BrowsCap) GetBrowser(userAgent string) (browser *Browser, ok bool) {
 	agent := mapToBytes(unicode.ToLower, userAgent)
 	defer bytesPool.Put(agent)
 
-	name := dict.tree.Find(agent)
+	name := browscap.dict.tree.Find(agent)
 	if name == "" {
 		return
 	}
 
-	browser = dict.getBrowser(name)
+	browser = browscap.dict.getBrowser(name)
 	if browser != nil {
 		ok = true
 	}

--- a/loader.go
+++ b/loader.go
@@ -6,6 +6,7 @@ package browscap_go
 import (
 	"bufio"
 	"bytes"
+	"io"
 	"os"
 )
 
@@ -20,20 +21,25 @@ var (
 	versionKey     = "Version"
 )
 
-func loadFromIniFile(path string) (*dictionary, error) {
+func NewBrowsCapFromFile(path string) (*BrowsCap, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
+	return NewBrowsCapFromReader(file)
+}
+
+func NewBrowsCapFromReader(reader io.Reader) (*BrowsCap, error) {
 	dict := newDictionary()
+	var version string
 
 	sectionName := ""
 
 	lineNum := 0
 
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 
@@ -97,5 +103,5 @@ func loadFromIniFile(path string) (*dictionary, error) {
 		return nil, err
 	}
 
-	return dict, nil
+	return &BrowsCap{dict, version}, nil
 }


### PR DESCRIPTION
This pull request changes two things:
- The initialized dictionary is returned by the NewBrowscapFromFile function instead of being stored in a global variable. This means that the initialized dictionary can be cleaned up if no longer needed.
- A new initialization function NewBrowscapFromReader is added, which can read the browscap from any io.Reader implementation, removing the need to store it in a file.